### PR TITLE
Possibility to configure server and client entrypoint

### DIFF
--- a/packages/core/devtools/src/libs/resources/resource-config-creator.ts
+++ b/packages/core/devtools/src/libs/resources/resource-config-creator.ts
@@ -11,7 +11,6 @@ import typescript from '@rollup/plugin-typescript';
 import { isProduction } from '../../environment';
 import { terser } from 'rollup-plugin-terser';
 import { PackageJson } from '../../types';
-import { hasFolder } from '@abstractflo/atlas-devtools';
 
 export class ResourceConfigCreator {
 

--- a/packages/core/devtools/src/libs/resources/resource-config-creator.ts
+++ b/packages/core/devtools/src/libs/resources/resource-config-creator.ts
@@ -11,6 +11,7 @@ import typescript from '@rollup/plugin-typescript';
 import { isProduction } from '../../environment';
 import { terser } from 'rollup-plugin-terser';
 import { PackageJson } from '../../types';
+import { hasFolder } from '@abstractflo/atlas-devtools';
 
 export class ResourceConfigCreator {
 
@@ -125,7 +126,7 @@ export class ResourceConfigCreator {
 
 
     const config = new ResourceConfigModel().cast({
-      input: resolvePath([resource.source, 'server', 'index.ts']),
+      input: typeof resource.config.serverMain !== "string" ? resolvePath([resource.source, 'server', 'index.ts']) : resolvePath([resource.source, ...resource.config.serverMain.split('/')]),
       output: {
         file: resolvePath([resource.output, 'server.js'])
       },
@@ -154,7 +155,7 @@ export class ResourceConfigCreator {
    */
   private createClientConfig(resource: GameResourceModel): RollupOptions {
     const config = new ResourceConfigModel().cast({
-      input: resolvePath([resource.source, 'client', 'index.ts']),
+      input: typeof resource.config.clientMain !== "string" ? resolvePath([resource.source, 'client', 'index.ts']) : resolvePath([resource.source, ...resource.config.clientMain.split('/')]),
       output: {
         file: resolvePath([resource.output, 'client.js'])
       },

--- a/packages/core/devtools/src/libs/resources/resource-manager.ts
+++ b/packages/core/devtools/src/libs/resources/resource-manager.ts
@@ -27,8 +27,8 @@ export class ResourceManager {
             config: { ...config, name: config.name || resourcePath },
             source: resolvePath([resourcePath]),
             output: resolvePath([outDir, resourcePath]),
-            isServer: !!hasFolder(`${resourcePath}/server`),
-            isClient: !!hasFolder(`${resourcePath}/client`),
+            isServer: !!hasFolder(`${resourcePath}/server`) || typeof config.serverMain === "string",
+            isClient: !!hasFolder(`${resourcePath}/client`) || typeof config.clientMain === "string",
             hasAssets: !!hasFolder(`${resourcePath}/assets`)
           });
         });

--- a/packages/core/devtools/src/models/game-resource-config.model.ts
+++ b/packages/core/devtools/src/models/game-resource-config.model.ts
@@ -32,10 +32,10 @@ export class GameResourceConfigModel extends JsonEntityModel {
   useStarImport: boolean = false;
 
   @Cast()
-  serverMain: string = 'server/index.ts';
+  serverMain: string;
 
   @Cast()
-  clientMain: string = 'client/index.ts';
+  clientMain: string;
 
   @Cast()
   readonly path: string;

--- a/packages/core/devtools/src/models/game-resource-config.model.ts
+++ b/packages/core/devtools/src/models/game-resource-config.model.ts
@@ -32,5 +32,11 @@ export class GameResourceConfigModel extends JsonEntityModel {
   useStarImport: boolean = false;
 
   @Cast()
+  serverMain: string = 'server/index.ts';
+
+  @Cast()
+  clientMain: string = 'client/index.ts';
+
+  @Cast()
   readonly path: string;
 }


### PR DESCRIPTION
Not sure if this is really needed but found no other way to do this (since i want to use 3.1 and there are no docs until release :D).
In my case i need this because i want to create only a client resource in the root folder of the atlas project.
The folder structure is the following:
- client (atlas project folder)
-- node_modules
-- retail
-- src
--- index.ts (client entrypoint)
-- .env
-- atlas-resource.json
-- atlas.json
-- package.json
-- tsconfig.eslint.json
-- tsconfig.json

With this pr you are able to specify ``"clientMain": "src/index.ts"`` in ``atlas-resource.json`` and the rollup config will be created with this input. 
The current behaviour is that it checks if there is a client folder which is a little inconvenient.

Overall would this change increase the flexibility of the folder structure.

If theres another/better solution for this please let me know